### PR TITLE
task: run go mod tidy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,9 @@ module github.com/openlyinc/pointy
 
 go 1.18
 
+require github.com/stretchr/testify v1.2.2
+
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/testify v1.2.2
 )


### PR DESCRIPTION
Since go1.17+ the way go.mod is organized is different to simplify the detection of transitive dependencies, this to help avoid detection of vulnerabilities on the transitive group

This PR simply runs `go mod tidy -compat=1.17` to auto fix the format

This is important as certain projects where we use pointy it currently flags yaml.v2 as a vulnerability being introduced by `testify`, which is at the same time introduced by pointy

Also I wonder if the project has considered updating `testify` to latest and maybe even enabling dependabot for the project (happy to contribute those changes)